### PR TITLE
Chore: minor optimizations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Git
+.gitattributes export-ignore
+.github/ export-ignore
+.gitignore export-ignore
+
+# Development files
+.editorconfig export-ignore
+composer.lock export-ignore

--- a/classes/BlurHash.php
+++ b/classes/BlurHash.php
@@ -8,15 +8,11 @@ use kornrunner\Blurhash\Blurhash as BHEncoder;
 class BlurHash
 {
   /**
-   * Blurs an image based on the blurhash algorithm, returns a data URI with an SVG filter.
-   * 
-   * @param File $file 
-   * @param float|null $ratio 
-   * @return string 
+   * Blurs an image based on the BlurHash algorithm, returns a data URI with an SVG filter.
    */
-  public static function blur(File $file, float $ratio = null): string
+  public static function blur(File $file, float|null $ratio = null): string
   {
-    $ratio = ($ratio ?? $file->ratio());
+    $ratio ??= $file->ratio();
 
     $blurhash = self::encode($file, $ratio); // Encode image with BlurHash Algorithm
     [$width, $height] = self::calcWidthHeight(option('tobimori.blurhash.decodeTarget'), $ratio); // Get target width and height for decoding
@@ -26,19 +22,14 @@ class BlurHash
   }
 
   /**
-   * Returns the blurhash for a Kirby file object.
-   * 
-   * @param File $file 
-   * @param float|null $ratio 
-   * @return string 
+   * Returns the BlurHash for a Kirby file object.
    */
-  public static function encode(File $file, float $ratio = null): string
+  public static function encode(File $file, float|null $ratio = null): string
   {
     $kirby = kirby();
 
     $id = $file->uuid() ?? $file->id();
-    $ratio = $ratio ?? $file->ratio();
-
+    $ratio ??= $file->ratio();
     $cache = $kirby->cache('tobimori.blurhash.encode');
 
     if (($cacheData = $cache->get($id)) !== null) {
@@ -87,11 +78,6 @@ class BlurHash
 
   /**
    * Decodes a BlurHash string to a binary image string.
-   * 
-   * @param string $blurhash 
-   * @param int $width 
-   * @param int $height 
-   * @return string 
    */
   public static function decode(string $blurhash, int $width, int $height): string
   {
@@ -124,9 +110,6 @@ class BlurHash
   /**
    * Returns an optimized URI-encoded string of an SVG for using in a src attribute.
    * Based on https://github.com/johannschopplich/kirby-blurry-placeholder/blob/main/BlurryPlaceholder.php#L65
-   * 
-   * @param string $data
-   * @return string
    */
   private static function svgToUri(string $data): string
   {
@@ -151,11 +134,6 @@ class BlurHash
   /**
    * Applies SVG filter and base64-encoding to binary image.
    * Based on https://github.com/johannschopplich/kirby-blurry-placeholder/blob/main/BlurryPlaceholder.php#L10
-   * 
-   * @param string $image
-   * @param int $width
-   * @param int $height
-   * @return string
    */
   private static function svgFilter(string $image, int $width, int $height): string
   {
@@ -182,11 +160,6 @@ class BlurHash
 
   /**
    * Returns a decoded BlurHash as a URI-encoded SVG with blur filter applied.
-   * 
-   * @param string $image
-   * @param int $width
-   * @param int $height
-   * @return string
    */
   public static function uri(string $image, int $width, int $height): string
   {
@@ -199,10 +172,6 @@ class BlurHash
   /**
    * Returns the width and height for a given ratio, based on a target entity count.    
    * Aims for a size of ~x entities (width * height = ~x)
-   * 
-   * @param int $target
-   * @param float $ratio
-   * @return array
    */
   private static function calcWidthHeight(int $target, float $ratio): array
   {

--- a/classes/BlurHash.php
+++ b/classes/BlurHash.php
@@ -170,7 +170,7 @@ class BlurHash
   }
 
   /**
-   * Returns the width and height for a given ratio, based on a target entity count.    
+   * Returns the width and height for a given ratio, based on a target entity count.
    * Aims for a size of ~x entities (width * height = ~x)
    */
   private static function calcWidthHeight(int $target, float $ratio): array

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9eed72d8f0e005c8b43f3ad02ad9b700",
+    "content-hash": "65fd6764b60046afcff42ff813e477ab",
     "packages": [
         {
             "name": "kornrunner/blurhash",
@@ -966,7 +966,9 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": ">=8.0.0"
+    },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"
 }

--- a/vendor/composer/ClassLoader.php
+++ b/vendor/composer/ClassLoader.php
@@ -42,6 +42,9 @@ namespace Composer\Autoload;
  */
 class ClassLoader
 {
+    /** @var \Closure(string):void */
+    private static $includeFile;
+
     /** @var ?string */
     private $vendorDir;
 
@@ -106,6 +109,7 @@ class ClassLoader
     public function __construct($vendorDir = null)
     {
         $this->vendorDir = $vendorDir;
+        self::initializeIncludeClosure();
     }
 
     /**
@@ -425,7 +429,7 @@ class ClassLoader
     public function loadClass($class)
     {
         if ($file = $this->findFile($class)) {
-            includeFile($file);
+            (self::$includeFile)($file);
 
             return true;
         }
@@ -555,18 +559,23 @@ class ClassLoader
 
         return false;
     }
-}
 
-/**
- * Scope isolated include.
- *
- * Prevents access to $this/self from included files.
- *
- * @param  string $file
- * @return void
- * @private
- */
-function includeFile($file)
-{
-    include $file;
+    private static function initializeIncludeClosure(): void
+    {
+        if (self::$includeFile !== null) {
+            return;
+        }
+
+        /**
+         * Scope isolated include.
+         *
+         * Prevents access to $this/self from included files.
+         *
+         * @param  string $file
+         * @return void
+         */
+        self::$includeFile = static function($file) {
+            include $file;
+        };
+    }
 }

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -1,8 +1,8 @@
 <?php return array(
     'root' => array(
         'name' => 'tobimori/kirby-blurhash',
-        'pretty_version' => '1.0.0',
-        'version' => '1.0.0.0',
+        'pretty_version' => '1.0.1',
+        'version' => '1.0.1.0',
         'reference' => NULL,
         'type' => 'kirby-plugin',
         'install_path' => __DIR__ . '/../../',
@@ -20,8 +20,8 @@
             'dev_requirement' => false,
         ),
         'tobimori/kirby-blurhash' => array(
-            'pretty_version' => '1.0.0',
-            'version' => '1.0.0.0',
+            'pretty_version' => '1.0.1',
+            'version' => '1.0.1.0',
             'reference' => NULL,
             'type' => 'kirby-plugin',
             'install_path' => __DIR__ . '/../../',


### PR DESCRIPTION
Absolutely stunning plugin! Especially useful, since I'm nowadays using Kirby as headless CMS most of the time.

I've made some minor improvements:
- Use null-coalescing operators of PHP 8 (like Kirby in 3.8+)
- PHP DocBlock comments are not needed anymore, since they are inferred from inline types.
- Added `.editorconfig` to trim trailing whitespace (was in one of your function titles)
- Added `.gitattributes` to exclude folders like `.github` from the generated ZIP file packed by Packagist and downloaded by Composer

Hope you like those minor improvements.