### PR TITLE
Fix: Return actual ID for given UUID instance

### DIFF
--- a/classes/BlurHash.php
+++ b/classes/BlurHash.php
@@ -242,9 +242,10 @@ class BlurHash
    */
   private static function getId(Asset|File $file): string
   {
-    if($file instanceof Asset)
+    if ($file instanceof Asset) {
       return $file->mediaHash();
+    }
 
-    return $file->uuid() ?? $file->id();
+    return $file->uuid()->id() ?? $file->id();
   }
 }


### PR DESCRIPTION
Using `uuid()` on files will return a [UUID class instance](https://github.com/getkirby/kirby/blob/7dcf359e3da2fa09923a3e0d851f2a74ae668e78/src/Uuid/Uuid.php#L43). 

To be more semantic, I think the actual ID for a given UUID should be used if available: `$file->uuid()->id()`.

Also added the curly brackets to be `PSR12` compliant, just like Kirby's code formatting guidelines.